### PR TITLE
Fix the URL JSON field to get the correct URL to show in GitHub

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,7 @@ jobs:
     name: PR Status Giphy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: PR Status Giphy
       uses: ./
       env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,7 +39,7 @@ jobs:
     needs: [docker_build]
     name: Docker Tag and Publish
     runs-on: ubuntu-latest
-    if: contains(github.ref,'master')
+    if: contains(github.ref,'main')
     steps:
     - uses: actions/checkout@master
     - uses: elgohr/Publish-Docker-Github-Action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ COPY ./src /action
 
 ENTRYPOINT ["/action/entrypoint.sh"]
 
-LABEL version="1.0.2"
-LABEL "repository"="https://github.com/jzweifel/pr-status-giphy-action"
-LABEL "homepage"="http://github.com/jzweifel"
-LABEL "maintainer"="Jacob Zweifel <jacob@jacobzweifel.com>"
+LABEL version="1.0.3"
+LABEL "repository"="https://github.com/dgteixeira/pr-status-giphy-action"
+LABEL "homepage"="http://github.com/dgteixeira"
+LABEL "maintainer"="Diogo Teixeira"
 
-LABEL "com.github.actions.name"="Pull Request Status Giphy Action"
+LABEL "com.github.actions.name"="Pull Request Status Giphy Action Fork"
 LABEL "com.github.actions.description"="A GitHub Action that displays a random thumbs up or thumbs down gif from Giphy when all checks on a Pull Request complete."
 LABEL "com.github.actions.icon"="check"
 LABEL "com.github.actions.color"="gray-dark"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pull Request Status Giphy Action
+# Pull Request Status Giphy Action Fork - Image URL Update for GitHub
 
 A GitHub Action that displays a random thumbs up or thumbs down gif from Giphy when all checks on a Pull Request complete.
 

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ function postCommentWithGif(gif) {
   console.log("Posting comment with gif...");
   return axios.post(
     githubPrCommentsUri,
-    { body: `![${gif.title}](${gif.image_url})\n\n${commentFooter}` },
+    { body: `![${gif.title}](${gif.images.original.webp})\n\n${commentFooter}` },
     {
       headers: githubApiHeaders
     }


### PR DESCRIPTION
This PR does:

- Changes HEAD branch to `main`;
- Changes the field to get the image URL from `image_url` to `images.original.webp` like stated in the oficial GIPHY documentation [here](https://developers.giphy.com/docs/api/endpoint/#random);
- Edited the Dockerfile to specify the new name;