### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,7 +42,7 @@ jobs:
     if: contains(github.ref,'master')
     steps:
     - uses: actions/checkout@master
-    - uses: elgohr/Publish-Docker-Github-Action@master
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: docker.pkg.github.com/jzweifel/pr-status-giphy-action/pr-status-giphy-action
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore